### PR TITLE
crypto/random: don't use insecure Math.random

### DIFF
--- a/lib/crypto/random.js
+++ b/lib/crypto/random.js
@@ -11,22 +11,8 @@ Random.getRandomBuffer = function(size) {
 
 /* insecure random bytes, but it never fails */
 Random.getPseudoRandomBuffer = function(size) {
-  var b32 = 0x100000000;
-  var b = new Buffer(size);
-  var r;
-
-  for (var i = 0; i <= size; i++) {
-    var j = Math.floor(i / 4);
-    var k = i - j * 4;
-    if (k === 0) {
-      r = Math.random() * b32;
-      b[i] = r & 0xff;
-    } else {
-      b[i] = (r = r >>> 8) & 0xff;
-    }
-  }
-
-  return b;
+  // insecure random bytes removed, let's use secure variant everywhere or fail
+  return Random.getRandomBuffer(size)
 };
 
 module.exports = Random;


### PR DESCRIPTION
This method is exported, so it is not removed for compatibility reasons.

Always use CSPRNG or fail to avoid accidental rng strength errors.
Note that crypto.Random.getPseudoRandomBuffer name does not give any indication of this being an unsafe PRNG.