### PR TITLE
use elliptic fork

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ bitcore.deps = {};
 bitcore.deps.bnjs = require('bn.js');
 bitcore.deps.bs58 = require('bs58');
 bitcore.deps.Buffer = Buffer;
-bitcore.deps.elliptic = require('elliptic');
+bitcore.deps.elliptic = require('@exodus/elliptic');
 bitcore.deps._ = require('lodash');
 
 // Internal usage, exposed for testing/advanced tweaking

--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -2,7 +2,7 @@
 
 var BN = require('./bn');
 var BufferUtil = require('../util/buffer');
-var ec = require('elliptic').curves.secp256k1;
+var ec = require('@exodus/elliptic').curves.secp256k1;
 var ecPoint = ec.curve.point.bind(ec.curve);
 var ecPointFromX = ec.curve.pointFromX.bind(ec.curve);
 

--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
     "request": "browser-request"
   },
   "dependencies": {
+    "@exodus/elliptic": "3.0.3",
     "blake-hash": "1.1.0",
     "bn.js": "2.0.4",
     "bs58": "2.0.1",
     "buffer-compare": "1.0.0",
     "create-hash": "1.2.0",
-    "elliptic": "3.0.3",
     "inherits": "2.0.1",
     "lodash": "3.10.1",
     "randombytes": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "@exodus/elliptic": "3.0.3",
+    "@exodus/elliptic": "3.0.3-dcr.0",
     "blake-hash": "1.1.0",
     "bn.js": "2.0.4",
     "bs58": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@exodus/elliptic@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@exodus/elliptic/-/elliptic-3.0.3.tgz#04f29e34ff72e17734c28f867dc52d43857fb27d"
+  integrity sha512-Il/5EUZoYzQ/R56b4oU67s9392pTqNsby0XGYdwAJWDZX7VMJTtyXvaqhMdsA8fCdHoDs7dOpxyb9hRBdDEfSQ==
+  dependencies:
+    bn.js "^2.0.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
+
 "@kollavarsham/gulp-coveralls@^0.2.2":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@kollavarsham/gulp-coveralls/-/gulp-coveralls-0.2.8.tgz#a79eb3c8cf3c0b132eaf1befd3433e32ffe080d5"
@@ -1574,16 +1584,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-elliptic@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
-  integrity sha1-hlybQgv75VAGuflp+XoNLESWZZU=
-  dependencies:
-    bn.js "^2.0.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    inherits "^2.0.1"
 
 elliptic@^6.0.0:
   version "6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@exodus/elliptic@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@exodus/elliptic/-/elliptic-3.0.3.tgz#04f29e34ff72e17734c28f867dc52d43857fb27d"
-  integrity sha512-Il/5EUZoYzQ/R56b4oU67s9392pTqNsby0XGYdwAJWDZX7VMJTtyXvaqhMdsA8fCdHoDs7dOpxyb9hRBdDEfSQ==
+"@exodus/elliptic@3.0.3-dcr.0":
+  version "3.0.3-dcr.0"
+  resolved "https://registry.yarnpkg.com/@exodus/elliptic/-/elliptic-3.0.3-dcr.0.tgz#c0b9163b2a92b66e4d19c162802d297a4bccb3b2"
+  integrity sha512-eSRQ7mT/+QN/0U2/DqM/lg53h+hmWztiTmd/HRFc7GNzGONyc9ovvHsu+yzjEE1d1vbx/tc3eZRFMrCjpfXQTw==
   dependencies:
-    bn.js "^2.0.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    inherits "^2.0.1"
+    bn.js "2.0.4"
+    brorand "1.1.0"
+    hash.js "1.1.5"
+    inherits "2.0.1"
 
 "@kollavarsham/gulp-coveralls@^0.2.2":
   version "0.2.8"
@@ -558,11 +558,6 @@ bn.js@2.0.4:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.0.4.tgz#220a7cd677f7f1bfa93627ff4193776fe7819480"
   integrity sha1-Igp81nf38b+pNif/QZN3b+eBlIA=
 
-bn.js@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.2.0.tgz#12162bc2ae71fc40a5626c33438f3a875cd37625"
-  integrity sha1-EhYrwq5x/EClYmwzQ486h1zTdiU=
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -635,7 +630,7 @@ brfs@^2.0.1:
     static-module "^3.0.2"
     through2 "^2.0.0"
 
-brorand@^1.0.1:
+brorand@1.1.0, brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
@@ -2650,6 +2645,14 @@ hash-base@^3.0.0:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+hash.js@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.5.tgz#e38ab4b85dfb1e0c40fe9265c0e9b54854c23812"
+  integrity sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"


### PR DESCRIPTION
made @exodus/elliptic@3.0.3-dcr.0 specifically for decred. This makes it easier to force everyone else to use @exodus/elliptic@6.4.1-precomputed via yarn resolutions.
locked deps there to match mobile. Without locking bn.js there, this module ended up using 2 bn.js's and experiencing weird errors, as the monkeypatched methods were missing in one of them:
https://github.com/indutny/elliptic/compare/master...ExodusMovement:3.0.3


sidenote: @roccomuso, i was wrong - this module does use elliptic, it's only the `bitcore.deps.elliptic` part that's not used