### PR TITLE
chore: upgrade to @exodus/elliptic@3.0.3-dcr.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "@exodus/elliptic": "3.0.3-dcr.0",
+    "@exodus/elliptic": "3.0.3-dcr.1",
     "blake-hash": "1.1.1",
     "bn.js": "2.0.4",
     "bs58": "2.0.1",


### PR DESCRIPTION
to dedupe bn.js

elliptic published from https://github.com/ExodusMovement/elliptic/commits/3.0.3