### PR TITLE
feat: replace bn.js with bigint wrapper

### DIFF
--- a/lib/crypto/bn.js
+++ b/lib/crypto/bn.js
@@ -1,8 +1,77 @@
 'use strict';
 
-var BN = require('bn.js');
 var $ = require('../util/preconditions');
 var _ = require('lodash');
+
+class BN {
+  #value
+
+  constructor(number, base, endian) {
+    if (number === undefined) {
+      this.#value = BigInt(0)
+    } else if (typeof number === 'number') {
+      this.#value = BigInt(number)
+    } else if (typeof number === 'string') {
+      if (base === 'hex') base = 16
+      if (base === undefined) base = /[a-f]/.test(number) ? 16 : 10
+      if (base === 10) {
+       this.#value = BigInt(number)
+      } else if (base === 16) {
+        this.#value = BigInt('0x' + number)
+      } else {
+        throw new Error('Unexpected base')
+      }
+    } else if (Buffer.isBuffer(number)) {
+      if (endian !== undefined && endian !== 'be' && endian !== 'le') {
+        throw new Error('Unexpected endian')
+      }
+      if (endian === 'le') number = Buffer.from(number).reverse()
+      this.#value = BigInt('0x' + number.toString('hex'))
+    } else if (Array.isArray(number)) {
+      const buf = Buffer.from(number)
+      if (!buf.every((v, i) => number[i] === v)) throw new Error('Unexpected input')
+      return new BN(buf, base, endian)
+    } else if (number instanceof BN) {
+      this.#value = number.#value
+    } else {
+      throw new Error('Unexpected input type')
+    }
+  }
+
+  cmp(b) {
+    if (this.#value === b.#value) return 0
+    return (this.#value < b.#value) ? -1 : 1
+  }
+
+  add(b) {
+    const res = new BN()
+    res.#value = this.#value + b.#value
+    return res
+  }
+
+  sub(b) {
+    const res = new BN()
+    res.#value = this.#value - b.#value
+    return res
+  }
+
+  neg() {
+    const res = new BN()
+    res.#value = BigInt(0) - this.#value
+    return res
+  }
+
+  toString(base = 10, padding) {
+    if (base === 'hex') base = 16
+    if (base === 10 || base === 16) {
+      const str = this.#value.toString(base)
+      if (!padding) return str
+      const pad = str.length - 1 - (str.length - 1) % padding + padding
+      return str.padStart(pad, '0')
+    }
+    throw new Error('Unexpected base')
+  }
+}
 
 var reversebuf = function(buf) {
   return Buffer.from(buf).reverse()
@@ -53,7 +122,7 @@ function fromSM(buf, opts) {
   if (buf[0] & 0x80) {
     buf[0] = buf[0] & 0x7f;
     ret = fromBuffer(buf);
-    ret.neg().copy(ret);
+    ret = ret.neg();
   } else {
     ret = fromBuffer(buf);
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@noble/hashes": "^1.3.3",
     "@noble/secp256k1": "^1.7.1",
     "blake-hash": "1.1.1",
-    "bn.js": "2.0.4",
     "bs58": "2.0.1",
     "inherits": "2.0.1",
     "lodash": "^4.17.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,11 +88,6 @@ blake-hash@1.1.1:
     inherits "^2.0.3"
     nan "^2.2.1"
 
-bn.js@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-2.0.4.tgz#220a7cd677f7f1bfa93627ff4193776fe7819480"
-  integrity sha1-Igp81nf38b+pNif/QZN3b+eBlIA=
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
`bn.js` v2 is very old
replace it with a light implementation

Can be migrated to top-level native BigInt later

Let's release the version with bn.js first, and then investigate this