### PR TITLE
ci: pin github actions hashes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
  ## 📝 Summary

  
  This PR pins third-party GitHub Actions to full commit SHAs.
  Internal `ExodusMovement/...` actions are out of scope for this campaign and are intentionally not locked in these changes.
  This removes floating action references and reduces supply-chain risk by ensuring workflow execution uses reviewed, immutable upstream revisions instead of tags that can be moved.